### PR TITLE
docs(css): fix TOC anchor offset under sticky header

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -40,6 +40,17 @@
   color: #333;
 }
 
+/* Keep TOC anchor jumps clear of the sticky header */
+.md-typeset :target {
+  --md-scroll-margin: 4.35rem;
+}
+
+@media screen and (min-width: 76.25em) {
+  .md-header--lifted ~ .md-container .md-typeset :target {
+    --md-scroll-margin: 4.35rem;
+  }
+}
+
 /* Images with shadow */
 .md-typeset img {
   display: block;


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/docs-cds-rdm/issues/18